### PR TITLE
Fix error status persisting

### DIFF
--- a/lib/src/controllers/field_controller.dart
+++ b/lib/src/controllers/field_controller.dart
@@ -96,12 +96,10 @@ class FieldController<T> extends ChangeNotifier {
   }
 
   void _applyChange(T? newValue) {
-    final currentError = _valueNotifier.value.error;
-    final newStatus = currentError != null ? FieldStatus.error : FieldStatus.filled;
-
     _valueNotifier.value = _valueNotifier.value.copyWith(
       initialValue: newValue,
-      status: newStatus,
+      error: null,
+      status: FieldStatus.filled,
     );
 
     if (T == String && _textEditingController != null) {


### PR DESCRIPTION
## Summary
- clear existing validation error when field value updates

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3df8c0408328949858eff81e6f96